### PR TITLE
Check max length when writing MemoryStream

### DIFF
--- a/System.IO.Streams/MemoryStream.cs
+++ b/System.IO.Streams/MemoryStream.cs
@@ -453,6 +453,7 @@ namespace System.IO
         /// <param name="value">Value for the new capacity.</param>
         /// <returns><see langword="true"/> if allocation for a new array was successful. <see langword="false"/> otherwise.</returns>
         /// <exception cref="NotSupportedException"></exception>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
         private bool EnsureCapacity(int value)
         {
             if (value > _capacity)
@@ -464,9 +465,19 @@ namespace System.IO
                     newCapacity = CapacityDefaultSize;
                 }
 
+                if (value > MemStreamMaxLength)
+                {
+                    throw new ArgumentOutOfRangeException("value", $"MemoryStream can't be more than {MemStreamMaxLength} bytes");
+                }
+
                 if (newCapacity < _capacity * 2)
                 {
                     newCapacity = _capacity * 2;
+                }
+
+                if (newCapacity > MemStreamMaxLength)
+                {
+                    newCapacity = MemStreamMaxLength;
                 }
 
                 if (!_expandable && newCapacity > _capacity)

--- a/UnitTests/MemoryStreamUnitTests/Write.cs
+++ b/UnitTests/MemoryStreamUnitTests/Write.cs
@@ -385,6 +385,28 @@ namespace System.IO.MemoryStreamUnitTests
             }
         }
 
+        [TestMethod]
+        public void Write_AtMaxLength_Works()
+        {
+            var maxLength = 0xFFFF;
+            using (var ms = new MemoryStream())
+            {
+                ms.Position = maxLength - 1;
+                ms.WriteByte(0); // should resize the buffer to the max size
+            }
+        }
+
+        [TestMethod]
+        public void Write_AboveMaxLength_Throws()
+        {
+            var maxLength = 0xFFFF;
+            using (var ms = new MemoryStream())
+            {
+                ms.Position = maxLength;
+                Assert.ThrowsException(typeof(ArgumentOutOfRangeException), () => ms.WriteByte(0));
+            }
+        }
+
         #endregion Test Cases
     }
 }


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
- Check if MemoryStream max size is exceeded before resizing buffer on write
- Add unit tests to make sure limit is enforced

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Fixes the inconsistency that the MemoryStream max length is only enforced in `Position` setter, `SetLength()`, `Seek()`, etc. but not in `Write()`

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added unit tests, though due to the current issues with the test runner I couldn't check if they work.


## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
