### PR TITLE
Fix MemoryStream.CanWrite to allow read-only

### DIFF
--- a/System.IO.Streams/MemoryStream.cs
+++ b/System.IO.Streams/MemoryStream.cs
@@ -65,16 +65,7 @@ namespace System.IO
         /// The <see cref="CanRead"/>, <see cref="CanSeek"/>, and <see cref="CanWrite"/> properties are all set to <see langword="true"/>.
         /// </para>
         /// </remarks>
-        public MemoryStream(byte[] buffer)
-        {
-            _buffer = buffer ?? throw new ArgumentNullException();
-
-            _length = _capacity = buffer.Length;
-            _expandable = false;
-            _origin = 0;
-            _isOpen = true;
-            _isWritable = true;
-        }
+        public MemoryStream(byte[] buffer) : this(buffer, true) { }
 
         /// <summary>
         /// Initializes a new non-resizable instance of the <see cref="MemoryStream"/> class based on the specified byte array with the <see cref="CanWrite"/> property set as specified.
@@ -352,11 +343,7 @@ namespace System.IO
         public override void SetLength(long value)
         {
             EnsureOpen();
-
-            if(!CanWrite)
-            {
-                throw new NotSupportedException();
-            }
+            EnsureWritable();
 
             if (value > MemStreamMaxLength || value < 0)
             {
@@ -399,11 +386,7 @@ namespace System.IO
         public override void Write(byte[] buffer, int offset, int count)
         {
             EnsureOpen();
-
-            if (!CanWrite)
-            {
-                throw new NotSupportedException();
-            }
+            EnsureWritable();
 
             if (buffer == null)
             {
@@ -444,11 +427,7 @@ namespace System.IO
         public override void WriteByte(byte value)
         {
             EnsureOpen();
-
-            if (!CanWrite)
-            {
-                throw new NotSupportedException();
-            }
+            EnsureWritable();
 
             if (_position >= _capacity)
             {
@@ -489,6 +468,18 @@ namespace System.IO
             if (!_isOpen)
             {
                 throw new ObjectDisposedException();
+            }
+        }
+
+        /// <summary>
+        /// Check that stream is writable
+        /// </summary>
+        /// <exception cref="NotSupportedException"></exception>
+        private void EnsureWritable()
+        {
+            if (!CanWrite)
+            {
+                throw new NotSupportedException();
             }
         }
 

--- a/System.IO.Streams/MemoryStream.cs
+++ b/System.IO.Streams/MemoryStream.cs
@@ -338,7 +338,8 @@ namespace System.IO
 
         /// <inheritdoc/>
         /// <exception cref="ObjectDisposedException"></exception>
-        /// <exception cref="NotSupportedException">The stream buffer does not have the capacity to hold the data and is not expandable.</exception>
+        /// <exception cref="NotSupportedException">The stream buffer does not have the capacity to hold the 
+        /// data and is not expandable, and/or the stream is not writable.</exception>
         /// <exception cref="ArgumentOutOfRangeException">The MemoryStream max size was exceeded</exception>
         public override void SetLength(long value)
         {
@@ -378,7 +379,8 @@ namespace System.IO
 
         /// <inheritdoc/>
         /// <exception cref="ObjectDisposedException"></exception>
-        /// <exception cref="NotSupportedException">The stream buffer does not have the capacity to hold the data and is not expandable.</exception>
+        /// <exception cref="NotSupportedException">The stream buffer does not have the capacity to hold the
+        /// data and is not expandable, and/or the stream is not writable.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
         /// The MemoryStream max size was exceeded or
         /// <paramref name="offset"/> or <paramref name="count"/> are less than 0
@@ -422,7 +424,8 @@ namespace System.IO
 
         /// <inheritdoc/>
         /// <exception cref="ObjectDisposedException"></exception>
-        /// <exception cref="NotSupportedException">The stream buffer does not have the capacity to hold the data and is not expandable.</exception>
+        /// <exception cref="NotSupportedException">The stream buffer does not have the capacity to hold the
+        /// data and is not expandable, and/or the stream is not writable.</exception>
         /// <exception cref="ArgumentOutOfRangeException">The MemoryStream max size was exceeded</exception>
         public override void WriteByte(byte value)
         {
@@ -472,7 +475,7 @@ namespace System.IO
         }
 
         /// <summary>
-        /// Check that stream is writable
+        /// Check that stream is writable.
         /// </summary>
         /// <exception cref="NotSupportedException"></exception>
         private void EnsureWritable()

--- a/UnitTests/MemoryStreamUnitTests/CanWrite.cs
+++ b/UnitTests/MemoryStreamUnitTests/CanWrite.cs
@@ -51,5 +51,19 @@ namespace System.IO.MemoryStreamUnitTests
                  OutputHelper.WriteLine($"Unexpected exception {ex}");
             }
         }
+
+        [TestMethod]
+        public void CanWrite_bool_false_Ctor()
+        {
+            // Arrange
+            byte[] buffer = new byte[1024];
+
+            // Act
+            using MemoryStream fs = new MemoryStream(buffer, false);
+
+            // Assert
+            Assert.IsFalse(fs.CanWrite, "Expected CanWrite == false, but got CanWrite == true");
+            Assert.ThrowsException(typeof(NotSupportedException), () => fs.WriteByte(0), "Expected exception when attempt to write to a read only stream.");
+        }
     }
 }

--- a/UnitTests/MemoryStreamUnitTests/CanWrite.cs
+++ b/UnitTests/MemoryStreamUnitTests/CanWrite.cs
@@ -53,17 +53,22 @@ namespace System.IO.MemoryStreamUnitTests
         }
 
         [TestMethod]
-        public void CanWrite_bool_false_Ctor()
+        [DataRow(true)]
+        [DataRow(false)]
+        public void CanWrite_bool_isWritable_Ctor(bool isWritable)
         {
             // Arrange
             byte[] buffer = new byte[1024];
 
             // Act
-            using MemoryStream fs = new MemoryStream(buffer, false);
+            using MemoryStream fs = new MemoryStream(buffer, isWritable);
 
             // Assert
-            Assert.IsFalse(fs.CanWrite, "Expected CanWrite == false, but got CanWrite == true");
-            Assert.ThrowsException(typeof(NotSupportedException), () => fs.WriteByte(0), "Expected exception when attempt to write to a read only stream.");
+            Assert.AreEqual(isWritable, fs.CanWrite, $"Expected CanWrite == {isWritable}, but got CanWrite == {!isWritable}");
+            if(!isWritable)
+            {
+                Assert.ThrowsException(typeof(NotSupportedException), () => fs.WriteByte(0), "Expected exception when attempt to write to a read only stream.");
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
- Add _isWritable backing CanWrite so that stream can be made read only via another constructor that specifies whether the stream is writable.
- Add Test for new constructor in CanWrite tests.
- Corrected constructor xml documentation that incorrectly stated that the MemoryStream allowed set length when buffer was provided.

## Motivation and Context
- Addresses nanoFramework/Home#1464.
- These modifications allow for read-only memory streams which are needed in the System.Net.Http library to solve part of issue 1464.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
This has been tested by adding a test to verify that the constructor creates the MemoryStream correctly.  This should not affect existing code, and existing tests continue to pass uneffected by changes.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
