### PR TITLE
Add `ReadOnlySpan` and `Span` overloads

### DIFF
--- a/System.IO.Streams/MemoryStream.cs
+++ b/System.IO.Streams/MemoryStream.cs
@@ -72,8 +72,9 @@ namespace System.IO
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is <see langword="null"/>.</exception>
         public MemoryStream(byte[] buffer, bool isWritable)
         {
-            _buffer = buffer ?? throw new ArgumentNullException();
+            ArgumentNullException.ThrowIfNull(buffer);
 
+            _buffer = buffer;
             _length = _capacity = buffer.Length;
             _expandable = false;
             _origin = 0;
@@ -181,7 +182,7 @@ namespace System.IO
             {
                 EnsureOpen();
 
-                if (value < 0 || value > MemStreamMaxLength)
+                if (value is < 0 or > MemStreamMaxLength)
                 {
                     throw new ArgumentOutOfRangeException();
                 }
@@ -196,7 +197,7 @@ namespace System.IO
         {
             EnsureOpen();
 
-            var bytesToRead = _length - _position;
+            int bytesToRead = _length - _position;
 
             if (bytesToRead > buffer.Length)
             {
@@ -209,7 +210,6 @@ namespace System.IO
             }
 
             new Span<byte>(_buffer, _position, bytesToRead).CopyTo(buffer);
-
             _position += bytesToRead;
 
             return bytesToRead;
@@ -384,10 +384,7 @@ namespace System.IO
             EnsureOpen();
             EnsureWritable();
 
-            if (buffer == null)
-            {
-                throw new ArgumentNullException();
-            }
+            ArgumentNullException.ThrowIfNull(buffer);
 
             if (offset < 0 || count < 0)
             {
@@ -399,44 +396,59 @@ namespace System.IO
                 throw new ArgumentException();
             }
 
-            int i = _position + count;
+            int newPosition = _position + count;
 
             // check for overflow
-            if (i > _length)
+            if (newPosition > _length)
             {
-                if (i > _capacity)
+                if (newPosition > _capacity)
                 {
-                    EnsureCapacity(i);
+                    EnsureCapacity(newPosition);
                 }
 
-                _length = i;
+                _length = newPosition;
             }
 
-            Array.Copy(buffer, offset, _buffer, _position, count);
-            _position = i;
+            new Span<byte>(buffer, offset, count).CopyTo(new Span<byte>(_buffer, _position, count));
+            _position = newPosition;
         }
 
-        /// <inheritdoc/>
-        /// <exception cref="ObjectDisposedException"></exception>
+        /// <summary>
+        /// Writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written.
+        /// </summary>
+        /// <param name="buffer">A region of memory. This method copies the contents of this region to the current stream.</param>
+        /// <exception cref="ObjectDisposedException">The current stream instance is closed.</exception>
         /// <exception cref="NotSupportedException">The stream buffer does not have the capacity to hold the
         /// data and is not expandable, and/or the stream is not writable.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">The MemoryStream max size was exceeded</exception>
-        public override void WriteByte(byte value)
+        /// <exception cref="ArgumentOutOfRangeException">The MemoryStream max size was exceeded.</exception>
+        /// <remarks>
+        /// Use the <see cref="CanWrite"/> property to determine whether the current instance supports writing.
+        /// If the write operation is successful, the position within the stream advances by the number of bytes written.
+        /// If an exception occurs, the position within the stream remains unchanged.
+        /// </remarks>
+        public override void Write(ReadOnlySpan<byte> buffer)
         {
             EnsureOpen();
             EnsureWritable();
 
-            if (_position >= _capacity)
+            int count = buffer.Length;
+            int newPosition = _position + count;
+
+            // check for overflow
+            if (newPosition > _length)
             {
-                EnsureCapacity(_position + 1);
+                if (newPosition > _capacity)
+                {
+                    EnsureCapacity(newPosition);
+                }
+
+                _length = newPosition;
             }
 
-            _buffer[_position++] = value;
+            // Copy ReadOnlySpan to buffer
+            buffer.CopyTo(new Span<byte>(_buffer, _position, count));
 
-            if (_position > _length)
-            {
-                _length = _position;
-            }
+            _position = newPosition;
         }
 
         /// <summary>

--- a/System.IO.Streams/Properties/AssemblyInfo.cs
+++ b/System.IO.Streams/Properties/AssemblyInfo.cs
@@ -1,5 +1,8 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -14,4 +17,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+// Mark the assembly as CLS compliant
+[assembly: CLSCompliant(true)]
 

--- a/System.IO.Streams/SeekOrigin.cs
+++ b/System.IO.Streams/SeekOrigin.cs
@@ -1,31 +1,44 @@
-//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.IO
 {
     /// <summary>
     /// Specifies the position in a stream to use for seeking.
     /// </summary>
-    /// <remarks>These constants match Win32's FILE_BEGIN, FILE_CURRENT, and FILE_END</remarks>
+    /// <remarks>
+    /// <para>
+    /// <see cref="SeekOrigin"/> is used by the Seek methods of <see cref="Stream"/>, <see cref="MemoryStream"/>, and other streams.
+    /// </para>
+    /// <para>
+    /// These constants match Win32's FILE_BEGIN, FILE_CURRENT, and FILE_END values.
+    /// </para>
+    /// </remarks>
     [Serializable]
     public enum SeekOrigin
     {
         /// <summary>
         /// Specifies the beginning of a stream.
         /// </summary>
+        /// <remarks>
+        /// Seeking to the beginning of a stream sets the position to zero.
+        /// </remarks>
         Begin = 0,
 
         /// <summary>
         /// Specifies the current position within a stream.
         /// </summary>
+        /// <remarks>
+        /// Seeking relative to the current position allows you to move forward or backward from the current position by specifying a positive or negative offset.
+        /// </remarks>
         Current = 1,
 
         /// <summary>
         /// Specifies the end of a stream.
         /// </summary>
+        /// <remarks>
+        /// Seeking relative to the end of a stream allows you to position at or before the end by specifying a zero or negative offset.
+        /// </remarks>
         End = 2,
     }
 }

--- a/System.IO.Streams/Stream.cs
+++ b/System.IO.Streams/Stream.cs
@@ -9,46 +9,38 @@ namespace System.IO
     [Serializable]
     public abstract class Stream : MarshalByRefObject, IDisposable
     {
-        // this value has been trimmed down from the original value that is used in full framework: 81920.
+        // this value has been trimmed down from the original value that is used in full framework:81920.
         private const int _CopyToBufferSize = 2048;
 
         /// <summary>
         /// When overridden in a derived class, gets a value indicating whether the current stream supports reading.
         /// </summary>
-        /// <value>
-        /// true if the stream supports reading; otherwise, false.
-        /// </value>
+        /// <value><see langword="true"/> if the stream supports reading; otherwise, <see langword="false"/>.</value>
         public abstract bool CanRead { get; }
 
         /// <summary>
         /// When overridden in a derived class, gets a value indicating whether the current stream supports seeking.
         /// </summary>
-        /// <value>
-        /// true if the stream supports seeking; otherwise, false.
-        /// </value>
+        /// <value><see langword="true"/> if the stream supports seeking; otherwise, <see langword="false"/>.</value>
         public abstract bool CanSeek { get; }
 
         /// <summary>
         /// Gets a value that determines whether the current stream can time out.
         /// </summary>
-        /// <value>
-        /// A value that determines whether the current stream can time out.
-        /// </value>
+        /// <value><see langword="true"/> if the current stream can time out; otherwise, <see langword="false"/>.</value>
         public virtual bool CanTimeout => false;
 
         /// <summary>
         /// When overridden in a derived class, gets a value indicating whether the current stream supports writing.
         /// </summary>
-        /// <value>
-        /// true if the stream supports writing; otherwise, false.
-        /// </value>
+        /// <value><see langword="true"/> if the stream supports writing; otherwise, <see langword="false"/>.</value>
         public abstract bool CanWrite { get; }
 
         /// <summary>
         /// When overridden in a derived class, gets the length in bytes of the stream.
         /// </summary>
         /// <value>
-        /// A long value representing the length of the stream in bytes.
+        /// A <see cref="long"/> value representing the length of the stream in bytes.
         /// </value>
         public abstract long Length { get; }
 
@@ -66,7 +58,7 @@ namespace System.IO
         /// <value>
         /// A value, in milliseconds, that determines how long the stream will attempt to read before timing out.
         /// </value>
-        /// <exception cref="System.InvalidOperationException"></exception>
+        /// <exception cref="InvalidOperationException">Always thrown. Timeouts are not supported on this stream.</exception>
         public virtual int ReadTimeout
         {
             get
@@ -86,7 +78,7 @@ namespace System.IO
         /// <value>
         /// A value, in milliseconds, that determines how long the stream will attempt to write before timing out.
         /// </value>
-        /// <exception cref="System.InvalidOperationException"></exception>
+        /// <exception cref="InvalidOperationException">Always thrown. Timeouts are not supported on this stream.</exception>
         public virtual int WriteTimeout
         {
             get
@@ -101,18 +93,15 @@ namespace System.IO
         }
 
         /// <summary>
-        /// Closes the current stream and releases any resources (such as sockets and file handles) associated with the current stream. 
+        /// Closes the current stream and releases any resources (such as sockets and file handles) associated with the current stream.
         /// Instead of calling this method, ensure that the stream is properly disposed.
         /// </summary>
         /// <remarks>
-        /// Stream used to require that all cleanup logic went into Close(),
-        /// which was thought up before we invented IDisposable.  However, we
-        /// need to follow the IDisposable pattern so that users can write
-        /// sensible subclasses without needing to inspect all their base
-        /// classes, and without worrying about version brittleness, from a
-        /// base class switching to the Dispose pattern.  We're moving
-        /// Stream to the Dispose(bool) pattern - that's where all subclasses
-        /// should put their cleanup starting in V2.
+        /// Stream used to require that all cleanup logic went into <see cref="Close"/>,
+        /// which was thought up before <see cref="IDisposable"/> existed. However, the
+        /// <see cref="IDisposable"/> pattern should be followed so that users can write
+        /// sensible subclasses without inspecting all their base classes and without
+        /// worrying about version brittleness.
         /// </remarks>
         public virtual void Close()
         {
@@ -126,46 +115,25 @@ namespace System.IO
         /// <param name="destination">The stream to which the contents of the current stream will be copied.</param>
         /// <exception cref="ArgumentNullException"><paramref name="destination"/> is <see langword="null"/>.</exception>
         /// <exception cref="NotSupportedException">
-        /// <para>
         /// The current stream does not support reading.
-        /// </para>
-        /// <para>
         /// -or-
-        /// </para>
-        /// <para>
         /// <paramref name="destination"/> does not support writing.
-        /// </para>
         /// </exception>
-        /// <exception cref="ObjectDisposedException">Either the current stream or <paramref name="destination"/> were closed before the <see cref="CopyTo"/> method was called.</exception>
+        /// <exception cref="ObjectDisposedException">Either the current stream or <paramref name="destination"/> was closed before the <see cref="CopyTo"/> method was called.</exception>
         /// <exception cref="IOException">An I/O error occurred.</exception>
         /// <remarks>
         /// Copying begins at the current position in the current stream, and does not reset the position of the destination stream after the copy operation is complete.
         /// </remarks>
         public void CopyTo(Stream destination)
         {
-            if (destination == null)
-            {
-#pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one 
-                throw new ArgumentNullException();
-#pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one 
-            }
+            ArgumentNullException.ThrowIfNull(destination);
 
-            if (!CanRead && !CanWrite)
+            if (!CanRead && !CanWrite || !destination.CanRead && !destination.CanWrite)
             {
                 throw new ObjectDisposedException();
             }
 
-            if (!destination.CanRead && !destination.CanWrite)
-            {
-                throw new ObjectDisposedException();
-            }
-
-            if (!CanRead)
-            {
-                throw new NotSupportedException();
-            }
-
-            if (!destination.CanWrite)
+            if (!CanRead || !destination.CanWrite)
             {
                 throw new NotSupportedException();
             }
@@ -194,7 +162,7 @@ namespace System.IO
         }
 
         /// <summary>
-        /// 
+        /// Finalizes the current instance of the <see cref="Stream"/> class.
         /// </summary>
         ~Stream()
         {
@@ -202,9 +170,9 @@ namespace System.IO
         }
 
         /// <summary>
-        /// Releases the unmanaged resources used by the Stream and optionally releases the managed resources.
+        /// Releases the unmanaged resources used by the <see cref="Stream"/> and optionally releases the managed resources.
         /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+        /// <param name="disposing"><see langword="true"/> to release both managed and unmanaged resources; <see langword="false"/> to release only unmanaged resources.</param>
         protected virtual void Dispose(bool disposing)
         {
         }
@@ -217,8 +185,8 @@ namespace System.IO
         /// <summary>
         /// When overridden in a derived class, sets the position within the current stream.
         /// </summary>
-        /// <param name="offset">A byte offset relative to the origin parameter.</param>
-        /// <param name="origin">A value of type SeekOrigin indicating the reference point used to obtain the new position.</param>
+        /// <param name="offset">A byte offset relative to the <paramref name="origin"/> parameter.</param>
+        /// <param name="origin">A value of type <see cref="SeekOrigin"/> indicating the reference point used to obtain the new position.</param>
         /// <returns>The new position within the current stream.</returns>
         public abstract long Seek(
             long offset,
@@ -229,21 +197,27 @@ namespace System.IO
         /// </summary>
         /// <param name="value">The desired length of the current stream in bytes.</param>
         public abstract void SetLength(long value);
-       
+
         /// <summary>
         /// When overridden in a derived class, reads a sequence of bytes from the current stream and advances the position within the stream by the number of bytes read.
         /// </summary>
         /// <param name="buffer">A region of memory. When this method returns, the contents of this region are replaced by the bytes read from the current source.</param>
-        /// <returns>The total number of bytes read into the buffer. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.</returns>
+        /// <returns>
+        /// The total number of bytes read into the <paramref name="buffer"/>. This can be less than the number of bytes requested if that many bytes are not currently available,
+        /// or zero (0) if the end of the stream has been reached.
+        /// </returns>
         public abstract int Read(Span<byte> buffer);
 
         /// <summary>
         /// When overridden in a derived class, reads a sequence of bytes from the current stream and advances the position within the stream by the number of bytes read.
         /// </summary>
-        /// <param name="buffer">An array of bytes. When this method returns, the buffer contains the specified byte array with the values between offset and (offset + count - 1) replaced by the bytes read from the current source.</param>
-        /// <param name="offset">The zero-based byte offset in buffer at which to begin storing the data read from the current stream.</param>
+        /// <param name="buffer">An array of bytes. When this method returns, the buffer contains the specified byte array with the values between <paramref name="offset"/> and (<paramref name="offset"/> + <paramref name="count"/> -1) replaced by the bytes read from the current source.</param>
+        /// <param name="offset">The zero-based byte offset in <paramref name="buffer"/> at which to begin storing the data read from the current stream.</param>
         /// <param name="count">The maximum number of bytes to be read from the current stream.</param>
-        /// <returns>The total number of bytes read into the buffer. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.</returns>
+        /// <returns>
+        /// The total number of bytes read into the <paramref name="buffer"/>. This can be less than the number of bytes requested if that many bytes are not currently available,
+        /// or zero (0) if the end of the stream has been reached.
+        /// </returns>
         public abstract int Read(
             byte[] buffer,
             int offset,
@@ -252,27 +226,37 @@ namespace System.IO
         /// <summary>
         /// Reads a byte from the stream and advances the position within the stream by one byte, or returns -1 if at the end of the stream.
         /// </summary>
-        /// <returns>The unsigned byte cast to an Int32, or -1 if at the end of the stream.</returns>
+        /// <returns>The unsigned byte cast to an <see cref="int"/>, or -1 if at the end of the stream.</returns>
         public virtual int ReadByte()
         {
             Span<byte> oneByteSpan = stackalloc byte[1];
-            var r = Read(oneByteSpan);
 
-            if (r == 0) return -1;
+            int r = Read(oneByteSpan);
 
-            return oneByteSpan[0];
+            return r == 0 ? -1 : oneByteSpan[0];
         }
 
         /// <summary>
         /// When overridden in a derived class, writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written.
         /// </summary>
-        /// <param name="buffer">An array of bytes. This method copies count bytes from buffer to the current stream.</param>
-        /// <param name="offset">The zero-based byte offset in buffer at which to begin copying bytes to the current stream.</param>
+        /// <param name="buffer">An array of bytes. This method copies <paramref name="count"/> bytes from <paramref name="buffer"/> to the current stream.</param>
+        /// <param name="offset">The zero-based byte offset in <paramref name="buffer"/> at which to begin copying bytes to the current stream.</param>
         /// <param name="count">The number of bytes to be written to the current stream.</param>
         public abstract void Write(
             byte[] buffer,
             int offset,
             int count);
+
+        /// <summary>
+        /// When overridden in a derived class, writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written.
+        /// </summary>
+        /// <param name="buffer">A region of memory. This method copies the contents of this region to the current stream.</param>
+        /// <remarks>
+        /// Use the <see cref="CanWrite"/> property to determine whether the current instance supports writing.
+        /// If the write operation is successful, the position within the stream advances by the number of bytes written.
+        /// If an exception occurs, the position within the stream remains unchanged.
+        /// </remarks>
+        public abstract void Write(ReadOnlySpan<byte> buffer);
 
         /// <summary>
         /// Writes a byte to the current position in the stream and advances the position within the stream by one byte.
@@ -281,8 +265,8 @@ namespace System.IO
         public virtual void WriteByte(byte value)
         {
             var oneByteArray = new byte[1];
-         oneByteArray[0] = value;
+            oneByteArray[0] = value;
             Write(oneByteArray, 0, 1);
-     }
+        }
     }
 }

--- a/System.IO.Streams/StreamReader.cs
+++ b/System.IO.Streams/StreamReader.cs
@@ -1,8 +1,5 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
 using System.Text;
@@ -39,7 +36,12 @@ namespace System.IO
         /// </summary>
         /// <value>The underlying stream.</value>
         /// <remarks>
-        /// You use this property to access the underlying stream. The StreamReader class buffers input from the underlying stream when you call one of the Read methods. If you manipulate the position of the underlying stream after reading data into the buffer, the position of the underlying stream might not match the position of the internal buffer. To reset the internal buffer, call the DiscardBufferedData method; however, this method slows performance and should be called only when absolutely necessary. The StreamReader constructors that have the detectEncodingFromByteOrderMarks parameter can change the encoding the first time you read from the StreamReader object.
+        /// <para>
+        /// You use this property to access the underlying stream. The <see cref="StreamReader"/> class buffers input from the underlying stream when you call one of the Read methods.
+        /// </para>
+        /// <para>
+        /// If you manipulate the position of the underlying stream after reading data into the buffer, the position of the underlying stream might not match the position of the internal buffer. To reset the internal buffer, call the DiscardBufferedData method; however, this method slows performance and should be called only when absolutely necessary.
+        /// </para>
         /// </remarks>
         public virtual Stream BaseStream { get; private set; }
 
@@ -47,37 +49,26 @@ namespace System.IO
         /// Gets the current character encoding that the current <see cref="StreamReader"/> object is using.
         /// </summary>
         /// <value>The current character encoding used by the current reader. The value can be different after the first call to any <see cref="Read()"/> method of <see cref="StreamReader"/>, since encoding autodetection is not done until the first call to a <see cref="Read()"/> method.</value>
-        public virtual Encoding CurrentEncoding => System.Text.Encoding.UTF8;
+        public virtual Encoding CurrentEncoding => Encoding.UTF8;
 
         /// <summary>
         /// Gets a value that indicates whether the current stream position is at the end of the stream.
         /// </summary>
         /// <value><see langword="true"/> if the current stream position is at the end of the stream; otherwise <see langword="false"/>.</value>
-        public bool EndOfStream
-        {
-            get
-            {
-                return _curBufLen == _curBufPos;
-            }
-        }
-        internal bool LeaveOpen
-        {
-            get { return !_closable; }
-        }
+        public bool EndOfStream => _curBufLen == _curBufPos;
+
+        internal bool LeaveOpen => !_closable;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StreamReader"/> class for the specified stream and optionally leaves the stream open.
         /// </summary>
         /// <param name="stream">The stream to be read.</param>
-                /// <param name="leaveOpen"><see langword="true"/> to leave the stream open after the <see cref="StreamReader"/> object is disposed; otherwise, <see langword="false"/>.</param>
+        /// <param name="leaveOpen"><see langword="true"/> to leave the stream open after the <see cref="StreamReader"/> object is disposed; otherwise, <see langword="false"/>.</param>
         /// <exception cref="ArgumentNullException"><paramref name="stream"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="stream"/> does not support reading.</exception>
         public StreamReader(Stream stream, bool leaveOpen = false)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException();
-            }
+            ArgumentNullException.ThrowIfNull(stream);
 
             if (!stream.CanRead)
             {
@@ -115,7 +106,7 @@ namespace System.IO
         /// <param name="disposing"><see langword="true"/> to release both managed and unmanaged resources; <see langword="false"/> to release only unmanaged resources.</param>
         /// <remarks>
         /// This method is called by the public <see cref="Dispose"/> method and the Finalize method. Dispose invokes the protected <see cref="Dispose"/> method with the disposing parameter set to <see langword="true"/>. Finalize invokes <see cref="Dispose"/> with disposing set to <see langword="false"/>.
-        /// When the disposing parameter is <see langword="true"/>, this method releases all resources held by any managed objects that the StreamReader object references.This method invokes the <see cref="Dispose"/> method of each referenced object.
+        /// When the disposing parameter is <see langword="true"/>, this method releases all resources held by any managed objects that the <see cref="StreamReader"/> object references. This method invokes the <see cref="Dispose"/> method of each referenced object.
         /// </remarks>
         protected override void Dispose(bool disposing)
         {
@@ -172,7 +163,7 @@ namespace System.IO
                     // retry read until response timeout expires
                     while (BaseStream.Length > 0 && totRead < _buffer.Length)
                     {
-                        int len = (int)(_buffer.Length - totRead);
+                        int len = _buffer.Length - totRead;
 
                         if (len > BaseStream.Length)
                         {
@@ -212,12 +203,15 @@ namespace System.IO
         /// </summary>
         /// <returns>The next character from the input stream represented as an <see cref="int"/> object, or -1 if no more characters are available.</returns>
         /// <remarks>
+        /// <para>
         /// This method overrides <see cref="TextReader.Read()"/>.
-        /// This method returns an integer so that it can return -1 if the end of the stream has been reached. If you manipulate the position of the underlying stream after reading data into the buffer, the position of the underlying stream might not match the position of the internal buffer.To reset the internal buffer, call the DiscardBufferedData method; however, this method slows performance and should be called only when absolutely necessary.
+        /// </para>
+        /// <para>
+        /// This method returns an integer so that it can return -1 if the end of the stream has been reached. If you manipulate the position of the underlying stream after reading data into the buffer, the position of the underlying stream might not match the position of the internal buffer. To reset the internal buffer, call the DiscardBufferedData method; however, this method slows performance and should be called only when absolutely necessary.
+        /// </para>
         /// </remarks>
         public override int Read()
         {
-            int byteUsed;
 
             while (true)
             {
@@ -229,7 +223,7 @@ namespace System.IO
                     0,
                     1,
                     false,
-                    out byteUsed,
+                    out int byteUsed,
                     out System.Int32 charUsed,
                     out _);
 
@@ -278,29 +272,29 @@ namespace System.IO
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> or <paramref name="count"/> is negative.</exception>
         /// <exception cref="ArgumentException">The buffer length minus <paramref name="index"/> is less than <paramref name="count"/>.</exception>
-        /// <exception cref="ObjectDisposedException">An I/O error occurs, such as the stream is closed.</exception>
+        /// <exception cref="ObjectDisposedException">The stream is closed.</exception>
         /// <remarks>
-        /// This method overrides TextReader.Read.
+        /// <para>
+        /// This method overrides <see cref="TextReader.Read(char[], int, int)"/>.
+        /// </para>
+        /// <para>
         /// This method returns an integer so that it can return 0 if the end of the stream has been reached.
-        /// When using the Read method, it is more efficient to use a buffer that is the same size as the internal buffer of the stream, where the internal buffer is set to your desired block size, and to always read less than the block size.If the size of the internal buffer was unspecified when the stream was constructed, its default size is 4 kilobytes(4096 bytes). If you manipulate the position of the underlying stream after reading data into the buffer, the position of the underlying stream might not match the position of the internal buffer.To reset the internal buffer, call the DiscardBufferedData method; however, this method slows performance and should be called only when absolutely necessary.
-        /// This method returns after either the number of characters specified by the count parameter are read, or the end of the file is reached. <see cref="TextReader.ReadBlock(char[], int, int)"/> is a blocking version of <see cref="Read(char[], int, int)"/>.
+        /// </para>
+        /// <para>
+        /// When using the Read method, it is more efficient to use a buffer that is the same size as the internal buffer of the stream, where the internal buffer is set to your desired block size, and to always read less than the block size. If the size of the internal buffer was unspecified when the stream was constructed, its default size is 4 kilobytes (4096 bytes). If you manipulate the position of the underlying stream after reading data into the buffer, the position of the underlying stream might not match the position of the internal buffer. To reset the internal buffer, call the DiscardBufferedData method; however, this method slows performance and should be called only when absolutely necessary.
+        /// </para>
+        /// <para>
+        /// This method returns after either the number of characters specified by the <paramref name="count"/> parameter are read, or the end of the file is reached. <see cref="TextReader.ReadBlock(char[], int, int)"/> is a blocking version of <see cref="Read(char[], int, int)"/>.
+        /// </para>
         /// </remarks>
         public override int Read(
             char[] buffer,
             int index,
             int count)
         {
-            if (buffer == null)
-            {
-                throw new ArgumentNullException();
-            }
+            ArgumentNullException.ThrowIfNull(buffer);
 
-            if (index < 0)
-            {
-                throw new ArgumentOutOfRangeException();
-            }
-
-            if (count < 0)
+            if (index < 0 || count < 0)
             {
                 throw new ArgumentOutOfRangeException();
             }
@@ -315,47 +309,48 @@ namespace System.IO
                 throw new ObjectDisposedException();
             }
 
-            int byteUsed, charUsed = 0;
+            return ReadHelper(new Span<char>(buffer, index, count));
+        }
 
-            if (_curBufLen == 0)
+        /// <summary>
+        /// Reads a specified maximum number of characters from the current stream into a character span.
+        /// </summary>
+        /// <param name="buffer">When this method returns, contains the characters read from the current source. If the total number of characters read is zero, the span remains unmodified.</param>
+        /// <returns>
+        /// The number of characters that have been read, or 0 if at the end of the stream and no data was read. The number will be less than or equal to the <paramref name="buffer"/> length, depending on whether the data is available within the stream.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">The stream is closed.</exception>
+        /// <remarks>
+        /// <para>
+        /// This method reads at most <paramref name="buffer"/>.Length characters from the current stream and stores them in <paramref name="buffer"/>.
+        /// </para>
+        /// <para>
+        /// This method returns an integer so that it can return 0 if the end of the stream has been reached.
+        /// </para>
+        /// </remarks>
+        public override int Read(Span<char> buffer)
+        {
+            if (_disposed)
             {
-                _ = FillBufferAndReset(count);
+                throw new ObjectDisposedException();
             }
 
-            int offset = 0;
-
-            while (true)
-            {
-                _decoder.Convert(
-                    _buffer,
-                    _curBufPos,
-                    _curBufLen - _curBufPos,
-                    buffer,
-                    offset,
-                    count,
-                    false,
-                    out byteUsed,
-                    out charUsed,
-                    out _);
-
-                count -= charUsed;
-                _curBufPos += byteUsed;
-                offset += charUsed;
-
-                if (count == 0 || (FillBufferAndReset(count) == 0))
-                {
-                    break;
-                }
-            }
-
-            return charUsed;
+            return ReadHelper(buffer);
         }
 
         /// <summary>
         /// Reads a line of characters from the current stream and returns the data as a string.
         /// </summary>
         /// <returns>The next line from the input stream, or <see langword="null"/> if the end of the input stream is reached.</returns>
-        /// <exception cref="Exception"></exception>
+        /// <exception cref="OutOfMemoryException">There is insufficient memory to allocate a buffer for the returned string.</exception>
+        /// <remarks>
+        /// <para>
+        /// A line is defined as a sequence of characters followed by a carriage return (\r), a line feed (\n), or a carriage return immediately followed by a line feed (\r\n). The string that is returned does not contain the terminating carriage return or line feed.
+        /// </para>
+        /// <para>
+        /// This method overrides <see cref="TextReader.ReadLine"/>.
+        /// </para>
+        /// </remarks>
         public override string ReadLine()
         {
             int bufLen = c_BufferSize;
@@ -421,15 +416,25 @@ namespace System.IO
         /// </summary>
         /// <returns>The rest of the stream as a string, from the current position to the end. If the current position is at the end of the stream, returns an empty string ("").</returns>
         /// <remarks>
-        /// This method overrides TextReader.ReadToEnd.
-        /// ReadToEnd works best when you need to read all the input from the current position to the end of the stream.If more control is needed over how many characters are read from the stream, use the Read(Char[], Int32, Int32) method overload, which generally results in better performance.
-        /// ReadToEnd assumes that the stream knows when it has reached an end.For interactive protocols in which the server sends data only when you ask for it and does not close the connection, ReadToEnd might block indefinitely because it does not reach an end, and should be avoided.
-        /// Note that when using the Read method, it is more efficient to use a buffer that is the same size as the internal buffer of the stream.If the size of the buffer was unspecified when the stream was constructed, its default size is 4 kilobytes (4096 bytes).
-        /// If the current method throws an OutOfMemoryException, the reader's position in the underlying Stream object is advanced by the number of characters the method was able to read, but the characters already read into the internal ReadLine buffer are discarded. If you manipulate the position of the underlying stream after reading data into the buffer, the position of the underlying stream might not match the position of the internal buffer. To reset the internal buffer, call the DiscardBufferedData method; however, this method slows performance and should be called only when absolutely necessary.
+        /// <para>
+        /// This method overrides <see cref="TextReader.ReadToEnd"/>.
+        /// </para>
+        /// <para>
+        /// ReadToEnd works best when you need to read all the input from the current position to the end of the stream. If more control is needed over how many characters are read from the stream, use the <see cref="Read(char[], int, int)"/> method overload, which generally results in better performance.
+        /// </para>
+        /// <para>
+        /// ReadToEnd assumes that the stream knows when it has reached an end. For interactive protocols in which the server sends data only when you ask for it and does not close the connection, ReadToEnd might block indefinitely because it does not reach an end, and should be avoided.
+        /// </para>
+        /// <para>
+        /// Note that when using the Read method, it is more efficient to use a buffer that is the same size as the internal buffer of the stream. If the size of the buffer was unspecified when the stream was constructed, its default size is 4 kilobytes (4096 bytes).
+        /// </para>
+        /// <para>
+        /// If the current method throws an <see cref="OutOfMemoryException"/>, the reader's position in the underlying <see cref="Stream"/> object is advanced by the number of characters the method was able to read, but the characters already read into the internal ReadLine buffer are discarded. If you manipulate the position of the underlying stream after reading data into the buffer, the position of the underlying stream might not match the position of the internal buffer. To reset the internal buffer, call the DiscardBufferedData method; however, this method slows performance and should be called only when absolutely necessary.
+        /// </para>
         /// </remarks>
         public override string ReadToEnd()
         {
-            char[] result = null;
+            char[] result;
 
             if (BaseStream.CanSeek)
             {
@@ -445,9 +450,22 @@ namespace System.IO
 
         private char[] ReadSeekableStream()
         {
-            char[] chars = new char[(int)BaseStream.Length];
+            // remaining bytes from current position to end of stream
+            int remainingBytes = (int)(BaseStream.Length - BaseStream.Position);
+            
+            // estimation of char count (may be less if multi-byte encoding)
+            // we'll allocate enough space and resize if needed
+            char[] chars = new char[remainingBytes];
 
-            _ = Read(chars, 0, chars.Length);
+            int charsRead = Read(chars, 0, chars.Length);
+            
+            // if we read fewer chars than allocated (due to multi-byte encoding), create a properly sized array
+            if (charsRead < chars.Length)
+            {
+                char[] result = new char[charsRead];
+                Array.Copy(chars, 0, result, 0, charsRead);
+                return result;
+            }
 
             return chars;
         }
@@ -470,9 +488,11 @@ namespace System.IO
 
                 totalRead += read;
 
-                if (read < c_BufferSize) // we are done
+                // we are done
+                if (read < c_BufferSize)
                 {
-                    if (read > 0) // copy last scraps
+                    // copy last scraps
+                    if (read > 0)
                     {
                         char[] newChars = new char[read];
 
@@ -497,6 +517,7 @@ namespace System.IO
                 char[] text = new char[totalRead];
 
                 int len = 0;
+
                 for (int i = 0; i < buffers.Count; ++i)
                 {
                     char[] buffer = (char[])buffers[i];
@@ -516,7 +537,10 @@ namespace System.IO
 
         private int FillBufferAndReset(int count)
         {
-            if (_curBufPos != 0) Reset();
+            if (_curBufPos != 0)
+            {
+                Reset();
+            }
 
             int totalRead = 0;
 
@@ -526,7 +550,10 @@ namespace System.IO
                 {
                     int spaceLeft = _buffer.Length - _curBufLen;
 
-                    if (count > spaceLeft) count = spaceLeft;
+                    if (count > spaceLeft)
+                    {
+                        count = spaceLeft;
+                    }
 
                     int read = BaseStream.Read(_buffer, _curBufLen, count);
 
@@ -546,12 +573,69 @@ namespace System.IO
             return totalRead;
         }
 
+        private int ReadHelper(Span<char> buffer)
+        {
+            int count = buffer.Length;
+
+            if (_curBufLen == 0)
+            {
+                _ = FillBufferAndReset(count);
+            }
+
+            int offset = 0;
+            int totalCharsRead = 0;
+
+            // Use temporary array for decoder since Decoder.Convert doesn't have a Span overload
+            char[] tempBuffer = new char[count];
+
+            while (true)
+            {
+                _decoder.Convert(
+                    _buffer,
+                    _curBufPos,
+                    _curBufLen - _curBufPos,
+                    tempBuffer,
+                    0,
+                    count,
+                    false,
+                    out int byteUsed,
+                    out int charUsed,
+                    out _);
+
+                // Copy decoded characters to the span
+                if (charUsed > 0)
+                {
+                    new Span<char>(
+                        tempBuffer,
+                        0,
+                        charUsed).CopyTo(buffer.Slice(offset, charUsed));
+                }
+
+                count -= charUsed;
+                _curBufPos += byteUsed;
+                offset += charUsed;
+                totalCharsRead += charUsed;
+
+                if (count == 0 || (FillBufferAndReset(count) == 0))
+                {
+                    break;
+                }
+            }
+
+            return totalCharsRead;
+        }
+
         private void Reset()
         {
             int bytesAvailable = _curBufLen - _curBufPos;
 
             // here we trust that the copy in place doe not overwrites data
-            Array.Copy(_buffer, _curBufPos, _buffer, 0, bytesAvailable);
+            Array.Copy(
+                _buffer,
+                _curBufPos,
+                _buffer,
+                0,
+                bytesAvailable);
 
             _curBufPos = 0;
             _curBufLen = bytesAvailable;

--- a/System.IO.Streams/StreamWriter.cs
+++ b/System.IO.Streams/StreamWriter.cs
@@ -1,8 +1,5 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
 
@@ -49,7 +46,7 @@ namespace System.IO
             set
             {
                 base.NewLine = value;
-                _newLineBytes = this.Encoding.GetBytes(value);
+                _newLineBytes = Encoding.GetBytes(value);
             }
         }
 
@@ -62,10 +59,7 @@ namespace System.IO
         /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
         public StreamWriter(Stream stream, bool leaveOpen = false)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException();
-            }
+            ArgumentNullException.ThrowIfNull(stream);
 
             if (!stream.CanWrite)
             {
@@ -83,9 +77,9 @@ namespace System.IO
         /// Closes the current <see cref="StreamWriter"/> object and the underlying stream.
         /// </summary>
         /// <remarks>
-        /// This method overrides <see cref="Stream.Close"/>.
+        /// This method overrides <see cref="TextWriter.Close"/>.
         /// This implementation of <see cref="Close"/> calls the <see cref="Dispose"/> method passing a true value.
-        /// You must call <see cref="Close"/> to ensure that all data is correctly written out to the underlying stream.Following a call to <see cref="Close"/>, any operations on the <see cref="StreamWriter"/> might raise exceptions. If there is insufficient space on the disk, calling <see cref="Close"/> will raise an exception.
+        /// You must call <see cref="Close"/> to ensure that all data is correctly written out to the underlying stream. Following a call to <see cref="Close"/>, any operations on the <see cref="StreamWriter"/> might raise exceptions. If there is insufficient space on the disk, calling <see cref="Close"/> will raise an exception.
         /// Flushing the stream will not flush its underlying encoder unless you explicitly call <see cref="Flush"/> or <see cref="Close"/>.
         /// </remarks>
         public override void Close()
@@ -94,11 +88,11 @@ namespace System.IO
         }
 
         /// <summary>
-        /// Causes any buffered data to be written to the underlying stream, releases the unmanaged resources used by the StreamWriter, and optionally the managed resources.
+        /// Causes any buffered data to be written to the underlying stream, releases the unmanaged resources used by the <see cref="StreamWriter"/>, and optionally the managed resources.
         /// </summary>
         /// <param name="disposing"><see langword="true"/> to release both managed and unmanaged resources; <see langword="false"/> to release only unmanaged resources.</param>
         /// <remarks>
-        /// When the disposing parameter is <see langword="true"/>, this method releases all resources held by any managed objects that this StreamWriter references. This method invokes the <see cref="Dispose"/> method of each referenced object.
+        /// When the disposing parameter is <see langword="true"/>, this method releases all resources held by any managed objects that this <see cref="StreamWriter"/> references. This method invokes the <see cref="Dispose"/> method of each referenced object.
         /// </remarks>
         protected override void Dispose(bool disposing)
         {
@@ -145,8 +139,8 @@ namespace System.IO
         /// <exception cref="ObjectDisposedException">The current writer is closed.</exception>
         /// <exception cref="IOException">An I/O error has occurred.</exception>
         /// <remarks>
-        /// This method overrides TextWriter.Flush.
-        /// Flushing the stream will not flush its underlying encoder unless you explicitly call Flush or <see cref="Close"/>.
+        /// This method overrides <see cref="TextWriter.Flush"/>.
+        /// Flushing the stream will not flush its underlying encoder unless you explicitly call <see cref="Flush"/> or <see cref="Close"/>.
         /// </remarks>
         public override void Flush()
         {
@@ -173,7 +167,7 @@ namespace System.IO
         /// <summary>
         /// Writes a character to the stream.
         /// </summary>
-        /// <param name="value"></param>
+        /// <param name="value">The character to write to the stream.</param>
         /// <remarks>
         /// This method overrides <see cref="TextWriter.Write(char)"/>.
         /// The specified character is written to the underlying stream unless the end of the stream is reached prematurely.
@@ -185,10 +179,27 @@ namespace System.IO
             WriteBytes(buffer, 0, buffer.Length);
         }
 
+        /// <summary>
+        /// Writes a character span to the stream.
+        /// </summary>
+        /// <param name="buffer">The character span to write.</param>
+        public override void Write(ReadOnlySpan<char> buffer)
+        {
+            byte[] tempBuf = Encoding.GetBytes(new string(buffer.ToArray()));
+
+            WriteBytes(tempBuf, 0, tempBuf.Length);
+        }
+
         /// <inheritdoc/>
         public override void Write(string value)
         {
+            if (value == null)
+            {
+                return;
+            }
+
             byte[] tempBuf = Encoding.GetBytes(value);
+
             WriteBytes(tempBuf, 0, tempBuf.Length);
         }
 
@@ -201,10 +212,11 @@ namespace System.IO
         /// <summary>
         /// Writes a string to the stream, followed by a line terminator.
         /// </summary>
+        /// <param name="value">The string to write. If the value is <see langword="null"/>, only the line terminator is written.</param>
         /// <remarks>
-        /// This overload is equivalent to the <see cref="TextWriter.Write(string)"/> overload.
-        /// The line terminator is defined by the CoreNewLine field.
-        /// This method does not search the specified string for individual newline characters(hexadecimal 0x000a) and replace them with NewLine.
+        /// This method overrides <see cref="TextWriter.WriteLine(string)"/>.
+        /// The line terminator is defined by the <see cref="NewLine"/> property.
+        /// This method does not search the specified string for individual newline characters (hexadecimal 0x000a) and replace them with <see cref="NewLine"/>.
         /// </remarks>
         public override void WriteLine(string value)
         {
@@ -252,5 +264,3 @@ namespace System.IO
         }
     }
 }
-
-

--- a/System.IO.Streams/TextReader.cs
+++ b/System.IO.Streams/TextReader.cs
@@ -1,8 +1,5 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.IO
 {
@@ -46,10 +43,10 @@ namespace System.IO
         /// <summary>
         /// Releases the unmanaged resources used by the <see cref="TextReader"/> and optionally releases the managed resources.
         /// </summary>
-        /// <param name="disposing"><see langword="true"/> to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+        /// <param name="disposing"><see langword="true"/> to release both managed and unmanaged resources; <see langword="false"/> to release only unmanaged resources.</param>
         /// <remarks>
-        /// This method is called by the public <see cref="Dispose()"/> method and the Finalize method. By default, this method specifies the disposing parameter as <see langword="true"/>. Finalize specifies the disposing parameter as false.
-        /// When the disposing parameter is true, this method releases all resources held by any managed objects that this TextReader references. This method invokes the <see cref="Dispose()"/> method of each referenced object.
+        /// This method is called by the public <see cref="Dispose()"/> method and the Finalize method. By default, this method specifies the disposing parameter as <see langword="true"/>. Finalize specifies the disposing parameter as <see langword="false"/>.
+        /// When the disposing parameter is <see langword="true"/>, this method releases all resources held by any managed objects that this <see cref="TextReader"/> references. This method invokes the <see cref="Dispose()"/> method of each referenced object.
         /// </remarks>
         protected virtual void Dispose(bool disposing)
         {
@@ -61,12 +58,13 @@ namespace System.IO
         /// <returns>An integer representing the next character to be read, or -1 if no more characters are available or the reader does not support seeking.</returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="Peek"/> method returns an integer value in order to determine whether the end of the file, or another error has occurred. This allows a user to first check if the returned value is -1 before casting it to a Char type.
+        /// The <see cref="Peek"/> method returns an integer value in order to determine whether the end of the file, or another error has occurred. This allows a user to first check if the returned value is -1 before casting it to a <see cref="char"/> type.
         /// </para>
         /// <para>
-        /// The current position of the <see cref="TextReader"/> is not changed by this operation.The returned value is -1 if no more characters are available.The default implementation returns -1.
+        /// The current position of the <see cref="TextReader"/> is not changed by this operation. The returned value is -1 if no more characters are available. The default implementation returns -1.
         /// </para>
-        /// <para>The TextReader class is an abstract class. Therefore, you do not instantiate it in your code.For an example of using the Peek method, see the StreamReader.Peek method.
+        /// <para>
+        /// The <see cref="TextReader"/> class is an abstract class. Therefore, you do not instantiate it in your code. For an example of using the <see cref="Peek"/> method, see the <see cref="StreamReader.Peek"/> method.
         /// </para>
         /// </remarks>
         public virtual int Peek()
@@ -95,10 +93,10 @@ namespace System.IO
         /// <returns>The number of characters that have been read. The number will be less than or equal to <paramref name="count"/>, depending on whether the data is available within the reader. This method returns 0 (zero) if it is called when no more characters are left to read.</returns>
         /// <remarks>
         /// <para>
-        /// This method returns after either count characters are read or the end of the file is reached. <see cref="ReadBlock"/> is a blocking version of this method.
+        /// This method returns after either <paramref name="count"/> characters are read or the end of the file is reached. <see cref="ReadBlock(char[], int, int)"/> is a blocking version of this method.
         /// </para>
         /// <para>
-        /// The <see cref="TextReader"/> class is an abstract class. Therefore, you do not instantiate it in your code.For an example of using the <see cref="Read(char[], int , int )"/> method, see the StreamReader.Read method.
+        /// The <see cref="TextReader"/> class is an abstract class. Therefore, you do not instantiate it in your code. For an example of using the <see cref="Read(char[], int, int)"/> method, see the <see cref="StreamReader.Read(char[], int, int)"/> method.
         /// </para>
         /// </remarks>
         public virtual int Read(char[] buffer, int index, int count)
@@ -107,18 +105,44 @@ namespace System.IO
         }
 
         /// <summary>
+        /// Reads a specified maximum number of characters from the current text reader into a character span.
+        /// </summary>
+        /// <param name="buffer">When this method returns, contains the character span with values replaced by the characters read from the current source.</param>
+        /// <returns>The number of characters that have been read, or 0 if at the end of the reader and no data was read. The number will be less than or equal to the <paramref name="buffer"/> length, depending on whether the data is available within the reader.</returns>
+        /// <remarks>
+        /// <para>
+        /// This method reads at most <paramref name="buffer"/>.Length characters from the current text reader and stores them in <paramref name="buffer"/>.
+        /// </para>
+        /// <para>
+        /// The <see cref="TextReader"/> class is an abstract class. Therefore, you do not instantiate it in your code. For an example of using the <see cref="Read(Span{char})"/> method, see the StreamReader.Read method.
+        /// </para>
+        /// </remarks>
+        public virtual int Read(Span<char> buffer)
+        {
+            char[] array = new char[buffer.Length];
+            int numRead = Read(array, 0, buffer.Length);
+
+            if (numRead > 0)
+            {
+                new Span<char>(array, 0, numRead).CopyTo(buffer);
+            }
+
+            return numRead;
+        }
+
+        /// <summary>
         /// Reads a specified maximum number of characters from the current text reader and writes the data to a buffer, beginning at the specified index.
         /// </summary>
-        /// <param name="buffer">When this method returns, this parameter contains the specified character array with the values between <paramref name="index"/> and (<paramref name="index"/> + <paramref name="count"/> -1) replaced by the characters read from the current source.</param>
+        /// <param name="buffer">When this method returns, this parameter contains the specified character array with the values between <paramref name="index"/> and (<paramref name="index"/> + <paramref name="count"/> - 1) replaced by the characters read from the current source.</param>
         /// <param name="index">The position in <paramref name="buffer"/> at which to begin writing.</param>
         /// <param name="count">The maximum number of characters to read.</param>
         /// <returns>The number of characters that have been read. The number will be less than or equal to <paramref name="count"/>, depending on whether all input characters have been read.</returns>
         /// <remarks>
         /// <para>
-        /// The position of the underlying text reader is advanced by the number of characters that were read into buffer.
+        /// The position of the underlying text reader is advanced by the number of characters that were read into <paramref name="buffer"/>.
         /// </para>
         /// <para>
-        /// The method blocks until either count characters are read, or all characters have been read.This is a blocking version of <see cref="Read(char[], int, int)"/>.
+        /// The method blocks until either <paramref name="count"/> characters are read, or all characters have been read. This is a blocking version of <see cref="Read(char[], int, int)"/>.
         /// </para>
         /// </remarks>
         public virtual int ReadBlock(char[] buffer, int index, int count)
@@ -139,10 +163,18 @@ namespace System.IO
         /// </summary>
         /// <returns>The next line from the reader, or <see langword="null"/> if all characters have been read.</returns>
         /// <remarks>
-        /// A line is defined as a sequence of characters followed by a carriage return (0x000d), a line feed (0x000a), a carriage return followed by a line feed, Environment.NewLine, or the end-of-stream marker. The string that is returned does not contain the terminating carriage return or line feed. The return value is null if the end of the input stream has been reached.
-        /// If the method throws an OutOfMemoryException exception, the reader's position in the underlying Stream is advanced by the number of characters the method was able to read, but the characters that were already read into the internal ReadLine buffer are discarded. Because the position of the reader in the stream cannot be changed, the characters that were already read are unrecoverable and can be accessed only by reinitializing the TextReader object. If the initial position within the stream is unknown or the stream does not support seeking, the underlying Stream also needs to be reinitialized.
-        /// To avoid such a situation and produce robust code you should use the Read method and store the read characters in a preallocated buffer.
-        /// The TextReader class is an abstract class. Therefore, you do not instantiate it in your code.For an example of using the ReadLine method, see the StreamReader.ReadLine method.
+        /// <para>
+        /// A line is defined as a sequence of characters followed by a carriage return (0x000d), a line feed (0x000a), a carriage return followed by a line feed, or the end-of-stream marker. The string that is returned does not contain the terminating carriage return or line feed. The return value is <see langword="null"/> if the end of the input stream has been reached.
+        /// </para>
+        /// <para>
+        /// If the method throws an <see cref="OutOfMemoryException"/>, the reader's position in the underlying <see cref="Stream"/> is advanced by the number of characters the method was able to read, but the characters that were already read into the internal ReadLine buffer are discarded. Because the position of the reader in the stream cannot be changed, the characters that were already read are unrecoverable and can be accessed only by reinitializing the <see cref="TextReader"/> object. If the initial position within the stream is unknown or the stream does not support seeking, the underlying <see cref="Stream"/> also needs to be reinitialized.
+        /// </para>
+        /// <para>
+        /// To avoid such a situation and produce robust code you should use the <see cref="Read(char[], int, int)"/> method and store the read characters in a preallocated buffer.
+        /// </para>
+        /// <para>
+        /// The <see cref="TextReader"/> class is an abstract class. Therefore, you do not instantiate it in your code. For an example of using the <see cref="ReadLine"/> method, see the <see cref="StreamReader.ReadLine"/> method.
+        /// </para>
         /// </remarks>
         public virtual string ReadLine()
         {
@@ -154,9 +186,16 @@ namespace System.IO
         /// </summary>
         /// <returns>A string that contains all characters from the current position to the end of the text reader.</returns>
         /// <remarks>
-        /// If the method throws an <see cref="OutOfMemoryException"/> exception, the reader's position in the underlying Stream is advanced by the number of characters the method was able to read, but the characters that were already read into the internal ReadToEnd buffer are discarded. Because the position of the reader in the stream cannot be changed, the characters that were already read are unrecoverable and can be accessed only by reinitializing the TextReader. If the initial position within the stream is unknown or the stream does not support seeking, the underlying Stream also needs to be reinitialized.
-        /// To avoid such a situation and produce robust code you should use the Read method and store the read characters in a preallocated buffer.
-        /// The <see cref="TextReader"/> class is an abstract class. Therefore, you do not instantiate it in your code.For an example of using the ReadToEnd method, see the StreamReader.ReadToEnd method.</remarks>
+        /// <para>
+        /// If the method throws an <see cref="OutOfMemoryException"/>, the reader's position in the underlying <see cref="Stream"/> is advanced by the number of characters the method was able to read, but the characters that were already read into the internal ReadToEnd buffer are discarded. Because the position of the reader in the stream cannot be changed, the characters that were already read are unrecoverable and can be accessed only by reinitializing the <see cref="TextReader"/>. If the initial position within the stream is unknown or the stream does not support seeking, the underlying <see cref="Stream"/> also needs to be reinitialized.
+        /// </para>
+        /// <para>
+        /// To avoid such a situation and produce robust code you should use the <see cref="Read(char[], int, int)"/> method and store the read characters in a preallocated buffer.
+        /// </para>
+        /// <para>
+        /// The <see cref="TextReader"/> class is an abstract class. Therefore, you do not instantiate it in your code. For an example of using the <see cref="ReadToEnd"/> method, see the <see cref="StreamReader.ReadToEnd"/> method.
+        /// </para>
+        /// </remarks>
         public virtual string ReadToEnd()
         {
             return null;

--- a/System.IO.Streams/TextWriter.cs
+++ b/System.IO.Streams/TextWriter.cs
@@ -1,8 +1,5 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
 
@@ -30,6 +27,15 @@ namespace System.IO
         /// <summary>
         /// Gets or sets the line terminator string used by the current <see cref="TextWriter"/>.
         /// </summary>
+        /// <value>The line terminator string for the current <see cref="TextWriter"/>.</value>
+        /// <remarks>
+        /// <para>
+        /// For non-Unix platforms, the default line terminator string is a carriage return followed by a line feed ('\r\n'). For Unix platforms, it's a line feed ('\n').
+        /// </para>
+        /// <para>
+        /// The line terminator string is written to the text stream whenever one of the <see cref="WriteLine"/> methods is called. In order for text written by the <see cref="TextWriter"/> to be readable by a <see cref="TextReader"/>, only "\n" or "\r\n" should be used as terminator strings. If <see cref="NewLine"/> is set to <see langword="null"/>, the default newline character is used instead.
+        /// </para>
+        /// </remarks>
         public virtual string NewLine
         {
             get
@@ -39,10 +45,7 @@ namespace System.IO
 
             set
             {
-                if (value == null)
-                {
-                    value = _InitialNewLine;
-                }
+                value ??= _InitialNewLine;
 
                 CoreNewLine = value.ToCharArray();
             }
@@ -51,10 +54,7 @@ namespace System.IO
         /// <summary>
         /// Closes the current writer and releases any system resources associated with the writer.
         /// </summary>
-        public virtual void Close()
-        {
-            Dispose();
-        }
+        public virtual void Close() => Dispose();
 
         /// <summary>
         /// Releases the unmanaged resources used by the <see cref="TextWriter"/> and optionally releases the managed resources.
@@ -118,17 +118,9 @@ namespace System.IO
         /// <exception cref="ArgumentException">The <paramref name="buffer"/> length minus <paramref name="index"/> is less than <paramref name="count"/>.</exception>
         public virtual void Write(char[] buffer, int index, int count)
         {
-            if (buffer == null)
-            {
-                throw new ArgumentNullException();
-            }
+            ArgumentNullException.ThrowIfNull(buffer);
 
-            if (index < 0)
-            {
-                throw new ArgumentOutOfRangeException();
-            }
-
-            if (count < 0)
+            if (index < 0 || count < 0)
             {
                 throw new ArgumentOutOfRangeException();
             }
@@ -148,65 +140,57 @@ namespace System.IO
         /// Writes the text representation of a <see cref="bool"/> value to the text stream.
         /// </summary>
         /// <param name="value">The <see cref="bool"/> value to write.</param>
-        public virtual void Write(bool value)
-        {
-            Write(value.ToString());
-        }
+        public virtual void Write(bool value) => Write(value.ToString());
 
         /// <summary>
         /// Writes the text representation of a 4-byte signed integer to the text stream.
         /// </summary>
         /// <param name="value">The 4-byte signed integer to write.</param>
-        public virtual void Write(int value)
-        {
-            Write(value.ToString());
-        }
+        public virtual void Write(int value) => Write(value.ToString());
 
         /// <summary>
         /// Writes the text representation of a 4-byte unsigned integer to the text stream.
         /// </summary>
         /// <param name="value">The 4-byte unsigned integer to write.</param>
-        [System.CLSCompliant(false)]
-        public virtual void Write(uint value)
-        {
-            Write(value.ToString());
-        }
+        [CLSCompliant(false)]
+        public virtual void Write(uint value) => Write(value.ToString());
 
         /// <summary>
         /// Writes the text representation of an 8-byte signed integer to the text stream.
         /// </summary>
         /// <param name="value">The 8-byte signed integer to write.</param>
-        public virtual void Write(long value)
-        {
-            Write(value.ToString());
-        }
+        public virtual void Write(long value) => Write(value.ToString());
 
         /// <summary>
         /// Writes the text representation of an 8-byte unsigned integer to the text stream.
         /// </summary>
         /// <param name="value">The 8-byte unsigned integer to write.</param>
-        [System.CLSCompliant(false)]
-        public virtual void Write(ulong value)
-        {
-            Write(value.ToString());
-        }
+        [CLSCompliant(false)]
+        public virtual void Write(ulong value) => Write(value.ToString());
 
         /// <summary>
         /// Writes the text representation of a 4-byte floating-point value to the text stream.
         /// </summary>
         /// <param name="value">The 4-byte floating-point value to write.</param>
-        public virtual void Write(float value)
-        {
-            Write(value.ToString());
-        }
+        public virtual void Write(float value) => Write(value.ToString());
 
         /// <summary>
         /// Writes the text representation of an 8-byte floating-point value to the text stream.
         /// </summary>
         /// <param name="value">The 8-byte floating-point value to write.</param>
-        public virtual void Write(double value)
-        {
-            Write(value.ToString());
+        public virtual void Write(double value) => Write(value.ToString());
+
+        /// <summary>
+        /// Writes a character span to the text stream.
+        /// </summary>
+        /// <param name="buffer">The character span to write to the text stream.</param>
+        /// <remarks>
+        /// This method writes the contents of the <paramref name="buffer"/> span to the text stream.
+        /// The default implementation creates a temporary array from the span and calls <see cref="Write(char[])"/>.
+        /// Derived classes can override this method to provide a more efficient implementation.
+        /// </remarks>
+        public virtual void Write(ReadOnlySpan<char> buffer)
+        { 
         }
 
         /// <summary>
@@ -236,10 +220,7 @@ namespace System.IO
         /// <summary>
         /// Writes a line terminator to the text stream.
         /// </summary>
-        public virtual void WriteLine()
-        {
-            Write(CoreNewLine);
-        }
+        public virtual void WriteLine() => Write(CoreNewLine);
 
         /// <summary>
         /// Writes a character to the text stream, followed by a line terminator.
@@ -300,7 +281,7 @@ namespace System.IO
         /// Writes the text representation of a 4-byte unsigned integer to the text stream, followed by a line terminator.
         /// </summary>
         /// <param name="value">The 4-byte unsigned integer to write.</param>
-        [System.CLSCompliant(false)]
+        [CLSCompliant(false)]
         public virtual void WriteLine(uint value)
         {
             Write(value);
@@ -321,7 +302,7 @@ namespace System.IO
         /// Writes the text representation of an 8-byte unsigned integer to the text stream, followed by a line terminator.
         /// </summary>
         /// <param name="value">The 8-byte unsigned integer to write.</param>
-        [System.CLSCompliant(false)]
+        [CLSCompliant(false)]
         public virtual void WriteLine(ulong value)
         {
             Write(value);

--- a/UnitTests/MemoryStreamUnitTests/CanRead.cs
+++ b/UnitTests/MemoryStreamUnitTests/CanRead.cs
@@ -1,19 +1,13 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {
     [TestClass]
     public class CanRead
     {
-
         [TestMethod]
         public void CanRead_Default_Ctor()
         {

--- a/UnitTests/MemoryStreamUnitTests/CanSeek.cs
+++ b/UnitTests/MemoryStreamUnitTests/CanSeek.cs
@@ -1,12 +1,7 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {

--- a/UnitTests/MemoryStreamUnitTests/CanWrite.cs
+++ b/UnitTests/MemoryStreamUnitTests/CanWrite.cs
@@ -1,26 +1,20 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {
     [TestClass]
     public class CanWrite
     {
-
         [TestMethod]
         public void CanWrite_Default_Ctor()
         {
             try
             {
                 OutputHelper.WriteLine("Verify CanWrite is true for default Ctor");
-         
+
                 using (MemoryStream fs = new MemoryStream())
                 {
                     Assert.IsTrue(fs.CanWrite, "Expected CanWrite == true, but got CanWrite == false");
@@ -28,7 +22,7 @@ namespace System.IO.MemoryStreamUnitTests
             }
             catch (Exception ex)
             {
-                 OutputHelper.WriteLine($"Unexpected exception {ex}");
+                OutputHelper.WriteLine($"Unexpected exception {ex}");
             }
         }
 
@@ -38,9 +32,9 @@ namespace System.IO.MemoryStreamUnitTests
             try
             {
                 OutputHelper.WriteLine("Verify CanWrite is true for Byte[] Ctor");
-         
+
                 byte[] buffer = new byte[1024];
-                
+
                 using (MemoryStream fs = new MemoryStream(buffer))
                 {
                     Assert.IsTrue(fs.CanWrite, "Expected CanWrite == true, but got CanWrite == false");
@@ -48,7 +42,7 @@ namespace System.IO.MemoryStreamUnitTests
             }
             catch (Exception ex)
             {
-                 OutputHelper.WriteLine($"Unexpected exception {ex}");
+                OutputHelper.WriteLine($"Unexpected exception {ex}");
             }
         }
 
@@ -65,7 +59,7 @@ namespace System.IO.MemoryStreamUnitTests
 
             // Assert
             Assert.AreEqual(isWritable, fs.CanWrite, $"Expected CanWrite == {isWritable}, but got CanWrite == {!isWritable}");
-            if(!isWritable)
+            if (!isWritable)
             {
                 Assert.ThrowsException(typeof(NotSupportedException), () => fs.WriteByte(0), "Expected exception when attempt to write to a read only stream.");
             }

--- a/UnitTests/MemoryStreamUnitTests/Close.cs
+++ b/UnitTests/MemoryStreamUnitTests/Close.cs
@@ -1,12 +1,7 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {

--- a/UnitTests/MemoryStreamUnitTests/Flush.cs
+++ b/UnitTests/MemoryStreamUnitTests/Flush.cs
@@ -1,12 +1,7 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {

--- a/UnitTests/MemoryStreamUnitTests/Length.cs
+++ b/UnitTests/MemoryStreamUnitTests/Length.cs
@@ -1,12 +1,7 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {

--- a/UnitTests/MemoryStreamUnitTests/MemoryStreamHelper.cs
+++ b/UnitTests/MemoryStreamUnitTests/MemoryStreamHelper.cs
@@ -1,12 +1,7 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {
@@ -104,7 +99,7 @@ namespace System.IO.MemoryStreamUnitTests
             byte[] byteArr = new byte[length];
 
             Random s_random = new Random();
-            
+
             s_random.NextBytes(byteArr);
 
             return byteArr;

--- a/UnitTests/MemoryStreamUnitTests/MemoryStreamUnitTests.nfproj
+++ b/UnitTests/MemoryStreamUnitTests/MemoryStreamUnitTests.nfproj
@@ -63,7 +63,6 @@
     <ProjectReference Include="..\..\System.IO.Streams\System.IO.Streams.nfproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="nano.runsettings" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/UnitTests/MemoryStreamUnitTests/MemoryStream_Ctor.cs
+++ b/UnitTests/MemoryStreamUnitTests/MemoryStream_Ctor.cs
@@ -1,12 +1,7 @@
-//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {
@@ -142,6 +137,5 @@ namespace System.IO.MemoryStreamUnitTests
         }
 
         #endregion Helper methods
-
     }
 }

--- a/UnitTests/MemoryStreamUnitTests/Position.cs
+++ b/UnitTests/MemoryStreamUnitTests/Position.cs
@@ -1,12 +1,7 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {

--- a/UnitTests/MemoryStreamUnitTests/Read.cs
+++ b/UnitTests/MemoryStreamUnitTests/Read.cs
@@ -1,12 +1,7 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 using System.Text;
 
 namespace System.IO.MemoryStreamUnitTests

--- a/UnitTests/MemoryStreamUnitTests/ReadByte.cs
+++ b/UnitTests/MemoryStreamUnitTests/ReadByte.cs
@@ -1,12 +1,7 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {

--- a/UnitTests/MemoryStreamUnitTests/Seek.cs
+++ b/UnitTests/MemoryStreamUnitTests/Seek.cs
@@ -1,19 +1,13 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {
     [TestClass]
     public class Seek
     {
-
         #region Helper methods
 
         private bool TestSeek(MemoryStream ms, long offset, SeekOrigin origin, long expectedPosition)

--- a/UnitTests/MemoryStreamUnitTests/SetLength.cs
+++ b/UnitTests/MemoryStreamUnitTests/SetLength.cs
@@ -1,19 +1,13 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {
     [TestClass]
     public class SetLength
     {
-
         #region Helper methods
 
         private bool TestLength(MemoryStream ms, long expectedLength)

--- a/UnitTests/MemoryStreamUnitTests/ToArray.cs
+++ b/UnitTests/MemoryStreamUnitTests/ToArray.cs
@@ -1,19 +1,13 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {
     [TestClass]
     public class ToArray
     {
-
         #region Helper methods
         private bool VerifyArray(byte[] data, int expected)
         {

--- a/UnitTests/MemoryStreamUnitTests/Write.cs
+++ b/UnitTests/MemoryStreamUnitTests/Write.cs
@@ -1,12 +1,7 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 using System.Text;
 
 namespace System.IO.MemoryStreamUnitTests

--- a/UnitTests/MemoryStreamUnitTests/WriteByte.cs
+++ b/UnitTests/MemoryStreamUnitTests/WriteByte.cs
@@ -1,19 +1,13 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {
     [TestClass]
     public class WriteByte
     {
-
         #region Helper methods
 
         private bool TestWrite(MemoryStream ms, int BytesToWrite)

--- a/UnitTests/MemoryStreamUnitTests/WriteTo.cs
+++ b/UnitTests/MemoryStreamUnitTests/WriteTo.cs
@@ -1,19 +1,13 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
-using System;
-using System.IO;
 
 namespace System.IO.MemoryStreamUnitTests
 {
     [TestClass]
     public class WriteTo
     {
-
         #region Test Cases
 
         [TestMethod]

--- a/UnitTests/StreamReaderWriterUnitTests/StreamReaderTests.cs
+++ b/UnitTests/StreamReaderWriterUnitTests/StreamReaderTests.cs
@@ -1,8 +1,5 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
 
@@ -61,6 +58,166 @@ namespace System.IO.MemoryStreamUnitTests
 
             // cannot set position on a disposed stream, test this by trying to set the position
             Assert.ThrowsException(typeof(ObjectDisposedException), () => stream.Position = 0);
+        }
+
+        [TestMethod]
+        public void TestReadArray()
+        {
+            string testText = "Hello, World! This is a test of Read with arrays!!";
+            byte[] bytes = System.Text.Encoding.UTF8.GetBytes(testText);
+
+            using MemoryStream stream = new MemoryStream(bytes);
+            using StreamReader reader = new StreamReader(stream);
+
+            // Test reading into a buffer
+            char[] buffer = new char[20];
+            int charsRead = reader.Read(buffer, 0, 20);
+
+            Assert.AreEqual(20, charsRead);
+            Assert.AreEqual("Hello, World! This i", new string(buffer));
+
+            // Read more
+            charsRead = reader.Read(buffer, 0, 20);
+            Assert.AreEqual(20, charsRead);
+            Assert.AreEqual("s a test of Read wit", new string(buffer));
+
+            // Read remaining (10 characters: "h arrays!!")
+            char[] smallBuffer = new char[10];
+            charsRead = reader.Read(smallBuffer, 0, 10);
+            Assert.AreEqual(10, charsRead);
+            Assert.AreEqual("h arrays!!", new string(smallBuffer));
+
+            // Verify end of stream
+            charsRead = reader.Read(buffer, 0, 20);
+            Assert.AreEqual(0, charsRead);
+        }
+
+        [TestMethod]
+        public void TestReadArray_EmptyStream()
+        {
+            using MemoryStream stream = new MemoryStream();
+            using StreamReader reader = new StreamReader(stream);
+
+            char[] buffer = new char[10];
+            int charsRead = reader.Read(buffer, 0, 10);
+
+            Assert.AreEqual(0, charsRead);
+        }
+
+        [TestMethod]
+        public void TestReadArray_SmallChunks()
+        {
+            string testText = "ABC";
+            byte[] bytes = System.Text.Encoding.UTF8.GetBytes(testText);
+
+            using MemoryStream stream = new MemoryStream(bytes);
+            using StreamReader reader = new StreamReader(stream);
+
+            // Read one character at a time
+            char[] buffer = new char[1];
+            
+            int charsRead = reader.Read(buffer, 0, 1);
+            Assert.AreEqual(1, charsRead);
+            Assert.AreEqual('A', buffer[0]);
+
+            charsRead = reader.Read(buffer, 0, 1);
+            Assert.AreEqual(1, charsRead);
+            Assert.AreEqual('B', buffer[0]);
+
+            charsRead = reader.Read(buffer, 0, 1);
+            Assert.AreEqual(1, charsRead);
+            Assert.AreEqual('C', buffer[0]);
+
+            charsRead = reader.Read(buffer, 0, 1);
+            Assert.AreEqual(0, charsRead);
+        }
+
+        [TestMethod]
+        public void TestReadArray_LargerThanStream()
+        {
+            string testText = "Short";
+            byte[] bytes = System.Text.Encoding.UTF8.GetBytes(testText);
+
+            using MemoryStream stream = new MemoryStream(bytes);
+            using StreamReader reader = new StreamReader(stream);
+
+            // Buffer larger than content
+            char[] buffer = new char[100];
+            int charsRead = reader.Read(buffer, 0, 100);
+
+            Assert.AreEqual(5, charsRead);
+            char[] result = new char[charsRead];
+            Array.Copy(buffer, 0, result, 0, charsRead);
+            Assert.AreEqual("Short", new string(result));
+        }
+
+        [TestMethod]
+        public void TestReadArray_Disposed()
+        {
+            using MemoryStream stream = new MemoryStream();
+            StreamReader reader = new StreamReader(stream);
+            reader.Dispose();
+
+            char[] buffer = new char[10];
+            Assert.ThrowsException(typeof(ObjectDisposedException), () => reader.Read(buffer, 0, 10));
+        }
+
+        [TestMethod]
+        public void TestReadToEnd()
+        {
+            string testText = "This is a complete test of ReadToEnd method. It should read all characters from the current position to the end of the stream.";
+            byte[] bytes = System.Text.Encoding.UTF8.GetBytes(testText);
+
+            using MemoryStream stream = new MemoryStream(bytes);
+            using StreamReader reader = new StreamReader(stream);
+
+            string result = reader.ReadToEnd();
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestReadToEnd_EmptyStream()
+        {
+            using MemoryStream stream = new MemoryStream();
+            using StreamReader reader = new StreamReader(stream);
+
+            string result = reader.ReadToEnd();
+
+            Assert.AreEqual("", result);
+        }
+
+        [TestMethod]
+        public void TestReadToEnd_AfterPartialRead()
+        {
+            string testText = "First part. Second part. Third part.";
+            byte[] bytes = System.Text.Encoding.UTF8.GetBytes(testText);
+
+            using MemoryStream stream = new MemoryStream(bytes);
+            using StreamReader reader = new StreamReader(stream);
+
+            // Read first 10 characters ("First part")
+            char[] buffer = new char[10];
+            reader.Read(buffer, 0, 10);
+
+            // ReadToEnd should read the rest (". Second part. Third part.")
+            string result = reader.ReadToEnd();
+
+            Assert.AreEqual(". Second part. Third part.", result);
+        }
+
+        [TestMethod]
+        public void TestReadToEnd_MultipleLines()
+        {
+            string testText = "Line 1\r\nLine 2\r\nLine 3";
+            byte[] bytes = System.Text.Encoding.UTF8.GetBytes(testText);
+
+            using MemoryStream stream = new MemoryStream(bytes);
+            using StreamReader reader = new StreamReader(stream);
+
+            string result = reader.ReadToEnd();
+
+            Assert.AreEqual(testText, result);
         }
     }
 }

--- a/UnitTests/StreamReaderWriterUnitTests/StreamReaderWriterUnitTests.nfproj
+++ b/UnitTests/StreamReaderWriterUnitTests/StreamReaderWriterUnitTests.nfproj
@@ -45,7 +45,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="nano.runsettings" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/UnitTests/StreamReaderWriterUnitTests/StreamWriterTests.cs
+++ b/UnitTests/StreamReaderWriterUnitTests/StreamWriterTests.cs
@@ -1,8 +1,5 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using nanoFramework.TestFramework;
 
@@ -53,6 +50,162 @@ namespace System.IO.MemoryStreamUnitTests
 
             // cannot set position on a disposed stream, test this by trying to set the position
             Assert.ThrowsException(typeof(ObjectDisposedException), () => stream.Position = 0);
+        }
+
+        [TestMethod]
+        public void TestWriteDouble()
+        {
+            using MemoryStream stream = new MemoryStream();
+            using (StreamWriter writer = new StreamWriter(stream, true))
+            {
+                writer.Write(3.14154);
+                writer.Write(" ");
+                writer.Write(-123.456);
+                writer.Write(" ");
+                writer.Write(0.0);
+            }
+
+            stream.Position = 0;
+
+            using StreamReader reader = new StreamReader(stream);
+            string result = reader.ReadToEnd();
+
+            Assert.IsTrue(result.Contains("3.14154"));
+            Assert.IsTrue(result.Contains("-123.456"));
+            Assert.IsTrue(result.Contains("0"));
+        }
+
+        [TestMethod]
+        public void TestWriteDoubleWithWriteLine()
+        {
+            using MemoryStream stream = new MemoryStream();
+            using (StreamWriter writer = new StreamWriter(stream, true))
+            {
+                writer.WriteLine(123.456);
+                writer.WriteLine(-789.011);
+            }
+
+            stream.Position = 0;
+
+            using StreamReader reader = new StreamReader(stream);
+            string line1 = reader.ReadLine();
+            string line2 = reader.ReadLine();
+
+            Assert.IsTrue(line1.Contains("123.456"));
+            Assert.IsTrue(line2.Contains("-789.011"));
+        }
+
+        [TestMethod]
+        public void TestWriteReadOnlySpan()
+        {
+            string testText = "Hello from Span!";
+            char[] charArray = testText.ToCharArray();
+            ReadOnlySpan<char> span = new ReadOnlySpan<char>(charArray);
+
+            using MemoryStream stream = new MemoryStream();
+            using (StreamWriter writer = new StreamWriter(stream, true))
+            {
+                writer.Write(span);
+            }
+
+            stream.Position = 0;
+
+            using StreamReader reader = new StreamReader(stream);
+            string result = reader.ReadToEnd();
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestWriteReadOnlySpan_EmptySpan()
+        {
+            ReadOnlySpan<char> span = ReadOnlySpan<char>.Empty;
+
+            using MemoryStream stream = new MemoryStream();
+            using (StreamWriter writer = new StreamWriter(stream, true))
+            {
+                writer.Write(span);
+            }
+
+            Assert.AreEqual(0, (int)stream.Length);
+        }
+
+        [TestMethod]
+        public void TestWriteReadOnlySpan_MultipleWrites()
+        {
+            ReadOnlySpan<char> span1 = new ReadOnlySpan<char>("First".ToCharArray());
+            ReadOnlySpan<char> span2 = new ReadOnlySpan<char>(" ".ToCharArray());
+            ReadOnlySpan<char> span3 = new ReadOnlySpan<char>("Second".ToCharArray());
+
+            using MemoryStream stream = new MemoryStream();
+            using (StreamWriter writer = new StreamWriter(stream, true))
+            {
+                writer.Write(span1);
+                writer.Write(span2);
+                writer.Write(span3);
+            }
+
+            stream.Position = 0;
+
+            using StreamReader reader = new StreamReader(stream);
+            string result = reader.ReadToEnd();
+
+            Assert.AreEqual("First Second", result);
+        }
+
+        [TestMethod]
+        public void TestWriteReadOnlySpan_LargeSpan()
+        {
+            // Create a large span that exceeds internal buffer size
+            char[] chars = new char[5000];
+            for (int i = 0; i < chars.Length; i++)
+            {
+                chars[i] = (char)('A' + (i % 26));
+            }
+            ReadOnlySpan<char> span = new ReadOnlySpan<char>(chars);
+
+            using MemoryStream stream = new MemoryStream();
+            using (StreamWriter writer = new StreamWriter(stream, true))
+            {
+                writer.Write(span);
+            }
+
+            stream.Position = 0;
+
+            using StreamReader reader = new StreamReader(stream);
+            string result = reader.ReadToEnd();
+
+            Assert.AreEqual(5000, result.Length);
+            Assert.AreEqual('A', result[0]);
+            Assert.AreEqual((char)('A' + (4999 % 26)), result[4999]);
+        }
+
+        [TestMethod]
+        public void TestWriteMixedTypes()
+        {
+            using MemoryStream stream = new MemoryStream();
+            using (StreamWriter writer = new StreamWriter(stream, true))
+            {
+                writer.Write("Integer: ");
+                writer.Write(42);
+                writer.Write(", Double: ");
+                writer.Write(3.14);
+                writer.Write(", Float: ");
+                writer.Write(2.71f);
+                writer.Write(", String: ");
+                ReadOnlySpan<char> span = new ReadOnlySpan<char>("Hello".ToCharArray());
+                writer.Write(span);
+            }
+
+            stream.Position = 0;
+
+            using StreamReader reader = new StreamReader(stream);
+            string result = reader.ReadToEnd();
+
+            Assert.IsTrue(result.Contains("42"));
+            Assert.IsTrue(result.Contains("3.14"));
+            Assert.IsTrue(result.Contains("2.71"));
+            Assert.IsTrue(result.Contains("Hello"));
         }
     }
 }


### PR DESCRIPTION
## Description
- These were addded to Stream and all reader and writer classes.
- Update and added unit tests accordingly.
- Major improvements in IntelliSense comments.
- Fix license header in most of the files.

## Motivation and Context
- Improvements following generic classes.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
